### PR TITLE
Refresh project

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 0.5
+
+Backward incompatible change
+
+- support for context is removed
+- decreased delay between attempts 20-40
+- support for launching tests in MacOS
+
 ### 0.4
 
 Backward incompatible change

--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,6 @@ it is suitable for many use cases.
 
 Key features are:
 - event handling is retriable at increased intervals between attempts
-- subscription context could be passed to a handler
 - support for the `@PreDestroy` lifecycle annotation
 - sending metrics using [Micrometer](https://github.com/micrometer-metrics/micrometer)
 
@@ -27,7 +26,7 @@ repositories {
 
 ```groovy
 dependencies {
-    implementation 'com.github.fred84:delayedQueue:0.4.0'
+    implementation 'com.github.fred84:delayedQueue:0.5.0'
 }
 ```
 
@@ -54,7 +53,6 @@ eventService = delayedEventService()
         .schedulingBatchSize(SCHEDULING_BATCH_SIZE)
         .enableScheduling(false)
         .pollingTimeout(POLLING_TIMEOUT)
-        .eventContextHandler(new DefaultEventContextHandler())
         .dataSetPrefix("")
         .retryAttempts(10)
         .metrics(new NoopMetrics())
@@ -78,24 +76,6 @@ eventService.enqueueWithDelayNonBlocking(new DummyEvent("1"), Duration.ofHours(1
 
 ```java
 eventService.close();
-```
-
-### Event context
-
-```java
-eventService.addHandler(
-        DummyEvent.class,
-        e -> Mono
-            .subscriberContext()
-            .doOnNext(ctx -> {
-                Map<String, String> eventContext = ctx.get("eventContext");
-                log.info("context key {}", eventContext.get("key"));
-            })
-            .thenReturn(true),
-        1
-);
-
-eventService.enqueueWithDelayNonBlocking(new DummyEvent("1"), Duration.ofHours(1), Map.of("key", "value")).subscribe();
 ```
 
 ## Contribution

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
     id "checkstyle"
 }
 
-group 'com.github.fred84'
-version '1.0-SNAPSHOT'
+group "com.github.fred84"
+version "1.0-SNAPSHOT"
 
 sourceCompatibility = 1.8
 
@@ -24,8 +24,8 @@ dependencies {
     implementation 'org.jetbrains:annotations:16.0.1'
 
     testImplementation "org.junit.jupiter:junit-jupiter:5.5.2"
-    testImplementation "org.hamcrest:hamcrest:2.1"
-    testImplementation 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.3'
+    testImplementation "org.assertj:assertj-core:3.27.2"
+    testImplementation "eu.rekawek.toxiproxy:toxiproxy-java:2.1.3"
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -38,5 +38,5 @@ tasks.withType(Test) {
 }
 
 wrapper {
-    gradleVersion = '5.6.2'
+    gradleVersion = "8.10"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,14 @@ version: '3'
 services:
   redis:
     image: redis:4-alpine
+    container_name: dq_redis
     ports:
       - "6379:6379"
 
   # works only on linux
   toxiproxy:
     image: shopify/toxiproxy
+    container_name: dq_toxiproxy
     ports:
       - "8474:8474"
-    network_mode: "host"
+      - "63790:63790"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sat Sep 28 18:56:25 MSK 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/src/main/java/com/github/fred84/queue/InnerSubscriber.java
+++ b/src/main/java/com/github/fred84/queue/InnerSubscriber.java
@@ -68,6 +68,9 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
 
         promise
                 .defaultIfEmpty(false)
+                // todo think how to inject log context enricher (e.g. what fields to set in logs)
+
+                // todo think of introducing an error which will terminate execution gracefully (e.g. no need to fail hard)
                 .doOnError(e -> LOG.warn("error occurred during handling event [{}]", envelope, e))
                 .onErrorReturn(false)
                 .flatMap(completed -> {
@@ -80,7 +83,12 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
                     }
                 })
                 .subscribeOn(handlerScheduler)
+<<<<<<< Updated upstream
                 .subscriberContext(c -> contextHandler.subscriptionContext(c, envelope.getLogContext()))
+=======
+                // todo context?
+                .contextWrite(c -> contextHandler.subscriptionContext(c, envelope.getLogContext()))
+>>>>>>> Stashed changes
                 .subscribe(r -> {
                     LOG.debug("event processing completed [{}]", envelope);
                     requestInner(1);

--- a/src/main/java/com/github/fred84/queue/InnerSubscriber.java
+++ b/src/main/java/com/github/fred84/queue/InnerSubscriber.java
@@ -2,7 +2,6 @@ package com.github.fred84.queue;
 
 import static java.lang.Boolean.TRUE;
 
-import com.github.fred84.queue.context.EventContextHandler;
 import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
 import java.util.function.Function;
@@ -71,7 +70,7 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
                     if (TRUE.equals(completed)) {
                         LOG.debug("deleting event {} from delayed queue", envelope.getPayload());
                         // todo we could also fail here!!! test me! with latch and toxyproxy
-                        return deleteCommand.apply(envelope.getPayload()).doOnNext(i -> LOG.debug("!!! deleted")).map(r -> true);
+                        return deleteCommand.apply(envelope.getPayload()).map(r -> true);
                     } else {
                         return Mono.just(true);
                     }

--- a/src/main/java/com/github/fred84/queue/InnerSubscriber.java
+++ b/src/main/java/com/github/fred84/queue/InnerSubscriber.java
@@ -19,7 +19,6 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
 
     private static final Logger LOG = LoggerFactory.getLogger(InnerSubscriber.class);
 
-    private final EventContextHandler contextHandler;
     private final Function<T, Mono<Boolean>> handler;
     private final int parallelism;
     private final StatefulRedisConnection<String, String> pollingConnection;
@@ -27,14 +26,12 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
     private final Function<Event, Mono<TransactionResult>> deleteCommand;
 
     InnerSubscriber(
-            EventContextHandler contextHandler,
             Function<T, Mono<Boolean>> handler,
             int parallelism,
             StatefulRedisConnection<String, String> pollingConnection,
             Scheduler handlerScheduler,
             Function<Event, Mono<TransactionResult>> deleteCommand
     ) {
-        this.contextHandler = contextHandler;
         this.handler = handler;
         this.parallelism = parallelism;
         this.pollingConnection = pollingConnection;
@@ -80,7 +77,6 @@ class InnerSubscriber<T extends Event> extends BaseSubscriber<EventEnvelope<T>> 
                     }
                 })
                 .subscribeOn(handlerScheduler)
-                .subscriberContext(c -> contextHandler.subscriptionContext(c, envelope.getLogContext()))
                 .subscribe(r -> {
                     LOG.debug("event processing completed [{}]", envelope);
                     requestInner(1);

--- a/src/test/java/com/github/fred84/queue/DelayedEventServiceTest.java
+++ b/src/test/java/com/github/fred84/queue/DelayedEventServiceTest.java
@@ -522,7 +522,7 @@ class DelayedEventServiceTest {
     }
 
     private Proxy createRedisProxy() throws IOException {
-        return toxiProxyClient.createProxy("redis", TOXIPROXY_IP + ":63790", "localhost:6379");
+        return toxiProxyClient.createProxy("redis", "0.0.0.0:63790", "dq_redis:6379");
     }
 
     private Mono<Void> enqueue(int num) {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration debug="true">
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{"ISO8601", UTC} %p %t [%X] - %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="stdout"/>
+    </root>
+</configuration>


### PR DESCRIPTION
1. Update gradle to more recent version. Nevertheless, the project still supports Java8
2. Add past undocumented changes to README
3. Drop support for an event context. It was working not as expected and it is more convenient to configure it on a client side.
4. Support tests in MacOS (with no Docker host networks)